### PR TITLE
Fixed buid.gradle to allow mixed java/kotlin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,8 +57,9 @@ dependencies {
 }
 
 sourceSets {
-    main.java.srcDirs += 'src/main/kotlin'
-    main.java.srcDirs += 'src/main/java'
+    main.java.srcDirs = []
+    main.kotlin.srcDirs += 'src/main/kotlin'
+    main.kotlin.srcDirs += 'src/main/java'
 }
 
 processResources {


### PR DESCRIPTION
see https://stackoverflow.com/questions/38131237/mixing-java-and-kotlin-in-gradle-project-kotlin-cannot-find-java-class for details.

I may be completely wrong here, but worth giving it a go.